### PR TITLE
[FIX] WP_Filesystem autodetection

### DIFF
--- a/wpforms-epfl-payonline.php
+++ b/wpforms-epfl-payonline.php
@@ -73,3 +73,12 @@ function wpforms_epfl_payonline() {
 }
 
 add_action( 'wpforms_loaded', 'wpforms_epfl_payonline' );
+
+add_action('wp_ajax_wpforms_tools_entries_export_step', function() {
+    // WPForms requires WP_Filesystem() to be of ->method === "direct".
+    // For some reason (likely pertaining to our symlink scheme),
+    // WordPress' autodetection fails.
+    add_filter('filesystem_method', function() {
+        return 'direct';
+    }, 10, 3);
+});


### PR DESCRIPTION
WPForms demands that `global $wp_filesystem` have `->method === "direct"` (in `src/Pro/Admin/Entries/Export/File.php`). For some reason, in EPFL-WordPress that is not the case (presumably for a reason of our own doing related to this symlink business.)

- Inject the correct decision using the `filesystem_method` filter
- For now, restrict that kludge to the sole use case for `WP_Filesystem` i.e. inside the `wpforms_tools_entries_export_step` AJAX call. We might want to hoist that higher later, should we encounter more cases of `WP_Filesystem` usage in the wild.